### PR TITLE
Draw stars using just the encompassing width

### DIFF
--- a/scripts/01-miscellaneous-shapes.lua
+++ b/scripts/01-miscellaneous-shapes.lua
@@ -16,7 +16,7 @@ drawcirclef(238, 171, 50, 14)
 drawcirclef(238, 171, 30, 13)
 drawcirclef(248, 181, 20, 12)
 drawcircle(300, 131, 80, 7)
-drawstar(70, 75, 100, 100, 4)
+drawstar(70, 75, 100, 4)
 drawfill(120, 125, 4)
 
 drawrefresh()  -- force a refresh of the drawing

--- a/scripts/02-stars-and-spheres.lua
+++ b/scripts/02-stars-and-spheres.lua
@@ -19,7 +19,7 @@ while i <= 416 - r do
 
   while j < 200 - r do
     if(y % 2 == 0) then
-      drawstar(i, j + 56 + 1, 2*r, 2*r, 10)
+      drawstar(i, j + 56 + 1, 2*r, 10)
     else
       drawcirclef(i + r, j + 56 + r, r, 4)
       drawcirclef(i + r - r/3, j + 56 + r - r/3, r/4, 10)


### PR DESCRIPTION
Draw stars using just the encompassing width as required by the latest Lua function implementation